### PR TITLE
Add open aq data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .venv
+node_modules
+package-lock.json
+package.json

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <div id="controls">
         <div id="geocoder-start" class="geocoder"></div>
         <div id="geocoder-end" class="geocoder"></div>
+        <div id="layer-switcher"></div>
+        <div id="layer-switcher-mp" class="mapboxgl-ctrl mapboxgl-ctrl-group"></div>
         <button id="route">Get Route</button>
     </div>
     <div id="slider-container" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Explore your routes with GHG data</title>
+    <script src="https://unpkg.com/openaq@1.2.1/dist/openaq.min.js"></script>
     <script src='https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.js'></script>
     <link href='https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.css' rel='stylesheet' />
     <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.7.0/mapbox-gl-geocoder.min.js'></script>


### PR DESCRIPTION
Update:
I’ve added:

- openAQ parameters picker (bottom right)
- Nearest along the route value of Currently picked parameter (top right)
- All the previously picked parameters averages (below nearest)
- OpenAQ handle Too many Requests by back-off

Note:
- Check console for failed openAQ requests, it should automatically retry while the animation plays, and update the averages and nearest values once all the requests go through
- Sampling 10-20 set of points along the route so openAQ wont error out. More than half of requests wont have a nearby station / sensor so will have to use the closest one.
- Code is messy and didnt bother to have granular commits (sorry :smile: )
- The coarseness in the path is still not fixed. this happens for longer routes exclusively
- if manually scrolling, will need to pause the animation and then scroll to see the nearest values

![image](https://github.com/user-attachments/assets/e7dbe384-47c2-4156-9c31-4346c3374ea5)


