### PR TITLE
add code and basic README for backend proxy

### DIFF
--- a/openaq_proxy/README.md
+++ b/openaq_proxy/README.md
@@ -1,0 +1,16 @@
+Simply proxy backend to query OpenAQ:
+
+ - Reads OpenAQ key from the environment
+ - Proxies queries to OpenAQ, injecting the key from the environment
+ - Serves appropriate CORS headers so that it can be queried from client-side Javascript
+
+This is setup on a small VPS server hosted with hetzner.de, with the domain name wastheinternetamistake.com pointing at it. 
+
+The server is running Ubuntu 22.04, with nginx serving the PHP files. 
+
+The PHP files are served from the root directory, with the cache directory in the same directory. 
+
+The cache directory is not stored in git, as it is not needed on other machines. 
+
+The environment variable for the OpenAQ key is set in /etc/php/8.3/fpm/pool.d/www.conf
+

--- a/openaq_proxy/index.php
+++ b/openaq_proxy/index.php
@@ -1,0 +1,76 @@
+<?php
+// Enable error reporting for debugging
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// OpenAQ API base URL
+$openaq_base_url = 'https://api.openaq.org/';
+
+// Get the API key from environment variable
+$api_key = getenv('OPENAQ_API_KEY');
+
+if (!$api_key) {
+    http_response_code(500);
+    echo json_encode(['error' => 'API key not set']);
+    exit;
+}
+
+// Get the URL from the query parameter
+$url = isset($_GET['url']) ? $_GET['url'] : null;
+
+if (!$url) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No URL provided']);
+    exit;
+}
+
+// Validate the URL
+if (strpos($url, $openaq_base_url) !== 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid URL. Must be an OpenAQ API URL.']);
+    exit;
+}
+
+// Generate a cache key based on the full URL
+$cache_key = md5($url);
+$cache_file = "cache/{$cache_key}.json";
+
+// Check if we have a valid cached response
+if (file_exists($cache_file) && (filemtime($cache_file) > (time() - 3600))) {
+    $cached_response = file_get_contents($cache_file);
+    header('Content-Type: application/json');
+    header('X-Cache: HIT');
+    echo $cached_response;
+    exit;
+}
+
+// If we don't have a cached response, make the API call
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'X-API-Key: ' . $api_key,
+    'Accept: application/json'
+]);
+
+$response = curl_exec($ch);
+$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+// Set appropriate headers
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($http_code >= 200 && $http_code < 300) {
+    // Cache the successful response
+    if (!file_exists('cache')) {
+        mkdir('cache', 0777, true);
+    }
+    file_put_contents($cache_file, $response);
+    header('X-Cache: MISS');
+    echo $response;
+} else {
+    http_response_code($http_code);
+    echo $response;
+}


### PR DESCRIPTION
Using an Open CORS proxy for the OpenAQ requests had lots of limitations and we were getting frequently throttled.

Also, the OpenAQ key is not meant to be exposed on the client-side.

This adds the code for a simple backend proxy for the OpenAQ requests, handling:

 - Validating requests are to OpenAQ
 - Reading key from the server environment
 - Implementing a simple file-system cache

A bit silly doing it in PHP, just seemed like the easiest way to get it running on a small VPS without much configuration.

Unfortunately, changes to the PHP backend code will not auto-deploy as part of CI, and currently, this needs to be manually copy-pasted onto the server. If other folks need access to the server, I can easily add your ssh key.

cc @muthukumaranR 